### PR TITLE
Allow User To Toggle PR WebHook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@
 
 # Ignore simplecov output
 /coverage/
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem "byebug", platform: :mri
   gem "pry-rails"
   gem "dotenv-rails"
+  gem "factory_girl_rails", "~> 4.0"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,11 @@ GEM
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
@@ -260,6 +265,7 @@ DEPENDENCIES
   byebug
   devise
   dotenv-rails
+  factory_girl_rails (~> 4.0)
   font-awesome-sass
   httparty
   jbuilder (~> 2.5)

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,0 +1,13 @@
+$(document).on('turbolinks:load', function() {
+  $('.repo').on('click', function() {
+    $status = $(this).find('.repo-status');
+
+    $(this).toggleClass('active');
+
+    if ($(this).hasClass('active')) {
+      $status.text('ON!');
+    } else {
+      $status.text('TURN CI ON?');
+    }
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto');
+@import "colors";
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "font-awesome-sprockets";

--- a/app/assets/stylesheets/colors.scss
+++ b/app/assets/stylesheets/colors.scss
@@ -2,3 +2,4 @@ $white: #fff;
 $base-green: #5cc85d;
 $base-gray: #b7b7b7;
 $secondary-gray: #b7b7b9;
+$navbar-gray: #C3C3C3;

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -16,6 +16,10 @@
   justify-content: center;
   margin: 0 auto;
   width: 50%;
+
+  a {
+    text-decoration: none;
+  }
 }
 
 .repo-list {
@@ -36,6 +40,11 @@
       background-color: $white;
       color: $base-gray;
     }
+
+    .repo-status {
+      color: $base-gray;
+      font-weight: bold;
+    }
   }
 
   .active {
@@ -44,12 +53,23 @@
     &:hover {
       background-color: $white;
       color: $base-green;
+
+      .repo-status {
+        background-color: $white;
+        color: $base-green;
+      }
+    }
+
+    .repo-status {
+      color: $white;
     }
   }
 }
 
 .repo-name {
+  color: $white;
   font-size: 20px;
   font-weight: bold;
+  text-decoration: none;
 }
 

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -3,12 +3,23 @@
   height: 40px;
 }
 
-.fa {
-  color: $white;
+.o-auth:hover {
+  .fa {
+    color: $base-green;
+  }
+
+  .button-text {
+    color: $base-green;
+  }
 }
 
-.fa:hover {
-  color: $base-green;
+.fa {
+  color: $white;
+  font-size: 18px;
+}
+
+.fa::before {
+  padding-right: 3px;
 }
 
 .button-text {
@@ -18,6 +29,7 @@
   font-size: 18px;
 }
 
-.button-text:hover {
-  color: $base-green;
+.navbar-right > li > a {
+  padding-bottom: 0;
+  padding-top: 12px;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,8 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     dashboard_path(resource.id)
   end
+
+  def after_sign_out_path_for(_resource)
+    root_path
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class DashboardController < ApplicationController
   def show
     @user = current_user
+    @repos = @user.repos.ordered_by_active
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:index]
+
   def index
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,0 +1,7 @@
+require "github_client"
+class WebhookController < ApplicationController
+  def toggle_pull_request_webhook
+    repo = Repo.find(params[:repo])
+    GithubClient.new(nil).toggle_webhook(repo)
+  end
+end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -3,4 +3,11 @@ class Repo < ApplicationRecord
 
   validates :full_name, presence: true
   validates :name, presence: true
+  validates :active, inclusion: { in: [true, false] }
+
+  scope :ordered_by_active, -> { order("active desc") }
+
+  def toggle_active
+    update_attributes(active: !active?)
+  end
 end

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -4,11 +4,13 @@
   </div>
   <div class="repo-list-div">
     <ul class="repo-list">
-      <% @user.repos.each do |repo| %>
-        <li class="repo">
-          <span class="repo-name"><%= repo.name %></span>
-          <p> Status </p><!-- To Replace -->
-        </li>
+      <% @repos.each do |repo| %>
+        <%= link_to toggle_webhook_path(repo: repo), remote: true, method: :post do %>
+          <li class="repo <%= repo.active? ? 'active' : '' %>">
+            <span class="repo-name"><%= repo.name %></span>
+            <p class="repo-status"><%= repo.active? ? 'ON!' : 'TURN CI ON?' %></p>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -17,9 +17,14 @@
         <li><a href="#">Help</a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to user_github_omniauth_authorize_path, class: "o-auth btn btn-success navbar-btn" do %>
-          <i class="fa fa-github"><span class="button-text">Sign In With Github</span></i>
-        <% end %>
+        <li>
+          <% if user_signed_in? %>
+            <%= link_to "Log Out", destroy_user_session_path, method: :delete %>
+          <% else %>
+            <%= link_to user_github_omniauth_authorize_path, class: "o-auth btn btn-success navbar-btn" do %>
+              <i class="fa fa-github"><span class="button-text">Sign In With Github</span></i>
+            <% end %>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,6 +4,7 @@ Devise.setup do |config|
   config.case_insensitive_keys = [:email]
   config.strip_whitespace_keys = [:email]
   config.skip_session_storage = [:http_auth]
+  config.secret_key = ENV.fetch("DEVISE_SECRET_KEY")
   config.stretches = Rails.env.test? ? 1 : 11
   config.reconfirmable = true
   config.expire_all_remember_me_on_sign_out = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: "oauth" }
   get "pages/index"
-
+  resources :dashboard, only: [:show]
+  post "/toggle_webhook", to: "webhook#toggle_pull_request_webhook"
   root "pages#index"
 end

--- a/db/migrate/20161101183239_add_active_to_repo.rb
+++ b/db/migrate/20161101183239_add_active_to_repo.rb
@@ -1,0 +1,5 @@
+class AddActiveToRepo < ActiveRecord::Migration[5.0]
+  def change
+    add_column :repos, :active, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20161102122939_add_hook_id_to_repo.rb
+++ b/db/migrate/20161102122939_add_hook_id_to_repo.rb
@@ -1,0 +1,5 @@
+class AddHookIdToRepo < ActiveRecord::Migration[5.0]
+  def change
+    add_column :repos, :hook_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161101183239) do
+ActiveRecord::Schema.define(version: 20161102122939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "repos", force: :cascade do |t|
-    t.string   "full_name",  null: false
-    t.string   "name",       null: false
+    t.string   "full_name",                  null: false
+    t.string   "name",                       null: false
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean  "active"
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "active",     default: false, null: false
+    t.string   "hook_id"
     t.index ["user_id"], name: "index_repos_on_user_id", using: :btree
   end
 

--- a/lib/github_client.rb
+++ b/lib/github_client.rb
@@ -1,30 +1,55 @@
 class GithubClient
-  def initialize(user, client = Octokit::Client)
+  def initialize(user, client = Octokit::Client.new(
+    access_token: ENV["ACCESS_TOKEN"],
+  ))
     @user = user
-    @_client = client
+    @client = client
   end
 
   def populate_user_repos
     response = get_user_repos
     response.each do |repo|
-      Repo.
-        find_or_create_by!(
-          user: user,
-          name: repo["name"],
-          full_name: repo["full_name"],
-        )
+      Repo.find_or_create_by!(
+        user: user,
+        name: repo["name"],
+        full_name: repo["full_name"],
+        active: false,
+      )
     end
+  end
+
+  def toggle_webhook(repo)
+    if repo.active?
+      turn_webhook_off(repo)
+    else
+      turn_webhook_on(repo)
+    end
+    repo.toggle_active
   end
 
   private
 
-  attr_reader :user
+  attr_reader :user, :client
 
   def get_user_repos
     client.repositories(user.uid.to_i)
   end
 
-  def client
-    @_client ||= client.new(access_token: ENV["ACCESS_TOKEN"])
+  def turn_webhook_on(repo)
+    response = client.create_hook(
+      repo.full_name.to_s,
+      "web",
+      {
+        url: "to-be-replaced-ngrok",
+        content_type: "json",
+      },
+      events: ["push", "pull_request"],
+      active: true,
+    )
+    repo.update_attributes(hook_id: response[:id])
+  end
+
+  def turn_webhook_off(repo)
+    client.remove_hook(repo.full_name, repo.hook_id)
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,29 +1,10 @@
 require "rails_helper"
 
 RSpec.describe PagesController, type: :controller do
-  let(:user) {
-    User.create!(
-      email: "email@email.com",
-      password: "password",
-      first_name: "name",
-      username: "jacko",
-    ) 
-  }
-
   describe "#index" do
-    context "when a user is signed in" do
-      it "returns a status 200" do
-        sign_in user
-        get :index
-        expect(response).to have_http_status(200)
-      end
-    end
-
-    context "when a user is unauthorized" do
-      it "returns a status 302" do
-        get :index
-        expect(response).to have_http_status(302)
-      end
+    it "returns a status 200" do
+      get :index
+      expect(response).to have_http_status(200)
     end
   end
 end

--- a/spec/factories/repos.rb
+++ b/spec/factories/repos.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :repo do
+    user
+    name "repo_name"
+    full_name "user_name/repo_name"
+    active false
+    hook_id nil
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :user do
+    first_name "first_name"
+    username "user_name"
+    email "email@email.com"
+    password "password"
+    uid "11234154"
+  end
+end

--- a/spec/lib/github_client_spec.rb
+++ b/spec/lib/github_client_spec.rb
@@ -6,11 +6,23 @@ class TestOctokit
   def self.repositories(_uid)
     [
       {
-        id: 1,
         "name" => "repo_name",
         "full_name" => "user_name/repo_name",
       },
     ]
+  end
+
+  def self.create_hook(*_repo)
+    {
+      type: "Repository",
+      id: 10541623,
+      name: "web",
+      active: true,
+    }
+  end
+
+  def self.remove_hook(*_repo)
+    true
   end
 end
 
@@ -18,13 +30,8 @@ RSpec.describe GithubClient do
   describe "#populate_user_repos" do
     context "when the repo doesn't exist" do
       it "it tells Repo to create with user's repos" do
-        user = User.create!(
-          first_name: "name",
-          username: "jacko",
-          email: "email@email.com",
-          password: "password",
-          uid: 11234154,
-        )
+        user = build(:user)
+
         expect { GithubClient.new(user, TestOctokit).populate_user_repos }.
           to change(Repo, :count).
           by(1)
@@ -33,21 +40,66 @@ RSpec.describe GithubClient do
 
     context "when the repo exists" do
       it "doesnt change the count" do
-        user = User.create!(
-          first_name: "name",
-          username: "jacko",
-          email: "email@email.com",
-          password: "password",
-          uid: 11234154,
-        )
-        Repo.create!(
-          user: user,
-          name: "repo_name",
-          full_name: "user_name/repo_name",
-        )
+        user = create(:user)
+        create(:repo, user: user)
 
         expect { GithubClient.new(user, TestOctokit).populate_user_repos }.
           to_not change(Repo, :count)
+      end
+    end
+  end
+
+  describe "#toggle_webhook" do
+    context "when the repo is activated" do
+      it "sends the create_hook message to Github" do
+        user = build(:user)
+        repo = build(:repo, user: user)
+
+        response = { id: "1234" }
+        expect(TestOctokit).
+          to receive(:create_hook).
+          with(any_args).
+          and_return(response)
+
+        GithubClient.new(user, TestOctokit).toggle_webhook(repo)
+      end
+
+      it "changes active from false to true" do
+        user = build(:user)
+        repo = build(:repo, user: user)
+
+        GithubClient.new(user, TestOctokit).toggle_webhook(repo)
+
+        expect(repo.active?).to eq(true)
+      end
+
+      it "saves the hook_id" do
+        user = build(:user)
+        repo = build(:repo, user: user)
+
+        GithubClient.new(user, TestOctokit).toggle_webhook(repo)
+
+        expect(repo.hook_id).to_not be_nil
+      end
+    end
+
+    context "when the repo is deactivated" do
+      it "sends the remove_hook message to Github" do
+        user = build(:user)
+        repo = build(:repo, active: true, user: user)
+
+        expect(TestOctokit).to receive(:remove_hook).with(any_args)
+
+        GithubClient.new(user, TestOctokit).toggle_webhook(repo)
+      end
+
+      it "changes active from true to false" do
+        user = build(:user)
+        repo = build(:repo, active: true, user: user)
+
+        GithubClient.new(user, TestOctokit).toggle_webhook(repo)
+
+        expect(repo.active?).to eq(false)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("The Rails environment is in production mode!") if Rails.env.production?
 require "spec_helper"
 require "rspec/rails"
+require "factory_girl_rails"
 require "devise"
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -29,6 +30,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.include FactoryGirl::Syntax::Methods
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include Devise::Test::ControllerHelpers, type: :controller
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
When a user clicks on a repo, it triggers a request to Github which
creates a webhook. If the webhook was already active, it removes the
webhook. Created UI to reflect changes in Webhook Status.