### PR TITLE
Allow MultiUser Authentication

### DIFF
--- a/app/controllers/oauth_controller.rb
+++ b/app/controllers/oauth_controller.rb
@@ -5,7 +5,7 @@ class OauthController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
-      GithubClient.new(@user).populate_user_repos
+      GithubClient.new(@user, Octokit::Client.new).populate_user_repos
       sign_in_and_redirect @user, event: :authentication
       set_flash_message(
         :notice,

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -2,6 +2,9 @@ require "github_client"
 class WebhookController < ApplicationController
   def toggle_pull_request_webhook
     repo = Repo.find(params[:repo])
-    GithubClient.new(nil).toggle_webhook(repo)
+    user = repo.user
+    GithubClient.new(nil, Octokit::Client.new(
+                            access_token: user.github_access_token,
+    )).toggle_webhook(repo)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
       user.password = Devise.friendly_token[0, 20]
       user.username = auth.info.nickname
       user.first_name = auth.info.name
+      user.github_access_token = auth.credentials.token
     end
   end
 end

--- a/db/migrate/20161104171402_add_github_access_token_to_user.rb
+++ b/db/migrate/20161104171402_add_github_access_token_to_user.rb
@@ -1,0 +1,5 @@
+class AddGithubAccessTokenToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :github_access_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102122939) do
+ActiveRecord::Schema.define(version: 20161104171402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20161102122939) do
     t.string   "uid"
     t.string   "username",                            null: false
     t.string   "first_name",                          null: false
+    t.string   "github_access_token"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/lib/github_client.rb
+++ b/lib/github_client.rb
@@ -1,7 +1,5 @@
 class GithubClient
-  def initialize(user, client = Octokit::Client.new(
-    access_token: ENV["ACCESS_TOKEN"],
-  ))
+  def initialize(user, client)
     @user = user
     @client = client
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,8 +9,20 @@ RSpec.describe User, type: :model do
         email: "email@email.com",
       )
     end
+    let(:credentials_hash) do
+      double(
+        token: "random_token",
+      )
+    end
 
-    let(:auth) { double(provider: "github", uid: "1224253", info: info_hash) }
+    let(:auth) do
+      double(
+        provider: "github",
+        uid: "1224253",
+        info: info_hash,
+        credentials: credentials_hash,
+      )
+    end
 
     context "when a matching user exists" do
       it "loads the record" do


### PR DESCRIPTION
Certain Github API requests require an access token. Save a user's
access_token on authorization, and make requests with it subsequently.